### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ cymem==1.31.2
 cytoolz==0.8.2
 dill==0.2.7.1
 docutils==0.14
-fuzzywuzzy==0.16.0
 gensim==3.4.0
 idna==2.6
 imagesize==1.0.0
@@ -38,9 +37,9 @@ preshed==1.0.0
 Pygments==2.2.0
 pyparsing==2.2.0
 python-dateutil==2.7.3
-python-Levenshtein==0.12.0
 pytz==2018.4
 PyYAML==3.12
+rapidfuzz==0.6.7
 regex==2017.4.5
 requests==2.18.4
 s3transfer==0.1.13

--- a/text_utils.py
+++ b/text_utils.py
@@ -2,7 +2,7 @@ from nltk.corpus import stopwords
 from nltk.tokenize import sent_tokenize, word_tokenize
 from nltk import pos_tag
 from .fast_utils import flatten
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 stop_words_cache = stopwords.words("english")
 
@@ -23,7 +23,7 @@ def fuzzy_word_remove(word_list):
         for i in range(len(word_list) -1):
             for j in range(len(word_list) -1):
                 if i != j:
-                    if (fuzz.token_sort_ratio(temp[i], temp[j]) > 75 ):
+                    if fuzz.token_sort_ratio(temp[i], temp[j], score_cutoff=75):
                         temp.remove(temp[j])
     except Exception as e:
         print(e)


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy